### PR TITLE
replace op_sibling

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.014000';
+requires 'perl', '5.022000';
 requires 'parent';
 requires 'B::Tools';
 requires 'Try::Tiny';

--- a/lib/B/Tap.xs
+++ b/lib/B/Tap.xs
@@ -150,11 +150,11 @@ static void rewrite_op(pTHX_ OP* target, OP* orig, OP* replacement, int depth) {
         break;
     }
 
-    if (target->op_sibling) {
-        if (target->op_sibling == orig) {
-            target->op_sibling = replacement;
+    if (OpHAS_SIBLING(target)) {
+        if (OpSIBLING(target) == orig) {
+            target->op_sibparent = replacement;
         } else {
-            rewrite_op(aTHX_ (OP*)target->op_sibling, orig, replacement, depth);
+            rewrite_op(aTHX_ (OP*)target->op_sibparent, orig, replacement, depth);
         }
     }
 }
@@ -193,7 +193,7 @@ CODE:
     /* Rewrite op tree. */
     OP * orig_op = (OP*)opp;
     OP * next_op = orig_op->op_next;
-    OP * sibling_op = orig_op->op_sibling;
+    OP * sibling_op = OpSIBLING(orig_op);
 
     /*
      * Before:
@@ -226,7 +226,7 @@ CODE:
     b_tap->op_flags    = (orig_op->op_flags & OPf_WANT) | OPf_KIDS;
     b_tap->op_first    = orig_op;
     b_tap->op_last     = (OP*)push_sv;
-    b_tap->op_sibling  = sibling_op;
+    b_tap->op_sibparent  = sibling_op;
 
     orig_op->op_next   = (OP*)push_sv;
     push_sv->op_next   = (OP*)b_tap;


### PR DESCRIPTION
recently perl renamed `op_sibling` field and add 2 macros for operation.

https://perldoc.jp/docs/perl/5.22.0/perl5220delta.pod#Internal32Changes

I checked test pass in 5.30.2 and 5.28.2.